### PR TITLE
Add API test for auto shim

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,10 +4,10 @@
 	"extends": "@ljharb",
 
 	"rules": {
-		"global-require": [1],
-		"max-statements": [2, 16],
-		"no-console": [0],
-		"no-invalid-this": [1],
-		"no-process-exit": [0]
+		"global-require": 1,
+		"max-statements": 0,
+		"no-console": 0,
+		"no-invalid-this": 1,
+		"no-process-exit": 0
 	}
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For any given “es-shim API”-compliant package `foo`, the following invariant
  - `require('foo').implementation` or `require('foo/implementation')` is a spec-compliant JS function, that will depend on a receiver (a “this” value) as the spec requires.
  - `require('foo').getPolyfill` or `require('foo/polyfill')` is a function that when invoked, will return the most compliant and performant function that it can - if a native version is available, and does not violate the spec, then the native function will be returned - otherwise, either the `implementation`, or a custom, wrapped version of the native function, will be returned. This is also the result that will be used as the default export.
  - `require('foo').shim` or `require('foo/shim')` is a function that when invoked, will call `getPolyfill`, and if the polyfill doesn’t match the built-in value, will install it into the global environment.
+ - `require('foo/auto')` will automatically invoke the `shim` method.
  - The only place the package may modify the environment is within its `shim` method.
  - Naturally, `npm test` must run the package’s tests.
  - In every way possible, the package must attempt to make itself robust against the environment being modified *after* it is `require`d.

--- a/api.js
+++ b/api.js
@@ -26,6 +26,7 @@ var isArg = function (x) {
 var isBound = args.some(argEquals('--bound'));
 var isProperty = args.some(argEquals('--property'));
 var skipShimPolyfill = args.some(argEquals('--skip-shim-returns-polyfill'));
+var skipAutoShim = args.some(argEquals('--skip-auto-shim'));
 var makeEntries = function (name) {
 	return [name, name];
 };
@@ -77,7 +78,7 @@ var validateModule = function validateAPIModule(t, nameOrFilePaths) {
 	});
 
 	t.test('implementation', function (st) {
-		st.equal(implementation, module.implementation, 'module.exports.implementaton === implementation.js');
+		st.equal(implementation, module.implementation, 'module.exports.implementation === implementation.js');
 		if (isProperty) {
 			st.comment('# SKIP implementation that is a data property need not be a function');
 		} else {
@@ -102,6 +103,17 @@ var validateModule = function validateAPIModule(t, nameOrFilePaths) {
 			} else {
 				st.equal(shim(), getPolyfill(), msg);
 			}
+		}
+		st.end();
+	});
+
+	t.test('auto', function (st) {
+		var msg = 'auto is present';
+		if (skipAutoShim) {
+			st.comment('# SKIP ' + msg);
+		} else {
+			require(packageDir + '/auto');
+			st.comment(msg + ' (pass `--skip-auto-shim` to skip this test)');
 		}
 		st.end();
 	});


### PR DESCRIPTION
This commit adds a test that will check for existence of `auto.js`.

This has been requested in https://github.com/es-shims/Promise.prototype.finally/pull/12